### PR TITLE
[TDOG-105] - Fix extra whitespaces after shuffle

### DIFF
--- a/autoload/shuffle.vim
+++ b/autoload/shuffle.vim
@@ -5,6 +5,7 @@ echom "Shuffle - Autoloading... "
 let s:pattern = '[^a-zA-Z0-9_"''$=]\+'
 let s:glue = ',\r'
 let s:newline = ''
+let s:trailing = ''
 
 " desc: Shuffle params into better presentation
 " a:sort -> 1 | 0
@@ -38,10 +39,11 @@ function! shuffle#OrderParams(sort, fold) abort
         let s:glue = ', '
     else
         let s:newline = '\r'
+        let s:trailing = repeat( ' ', indent( '.' ) )
     endif
 
     let joined_string = join( list_items, s:glue )
-    execute 's/'. @@ . '/'. s:newline . joined_string . s:newline . repeat( ' ', indent( '.' ) )
+    execute 's/'. @@ . '/'. s:newline . joined_string . s:newline . s:trailing
     if !a:fold
         execute (init_line + 1) . ',' . (init_line + items_len) . repeat( '>', indent_times )
     endif

--- a/test/tests/test_shuffle.vim
+++ b/test/tests/test_shuffle.vim
@@ -89,3 +89,12 @@ function Test_Shuffle_Real_Life_Raw_Input_Case()
     call assert_equal( 'let test = doTest(foo=2, bar=1)', getline( 1 ) )
     %bwipe!
 endfunction
+
+function Test_Shuffle_Indent_Method()
+    let indent_spaces = repeat( ' ', &shiftwidth )
+    call feedkeys( "i" . indent_spaces .  "(bar=1, foo=2)", 'xt' )
+    call feedkeys( "^", 'xt' )
+    call shuffle#OrderParams(1, 1)
+    call assert_equal( indent_spaces . '(foo=2, bar=1)', getline( 1 ) )
+    %bwipe!
+endfunction


### PR DESCRIPTION
Why:
* This is issue from indenting the funtion params
This change addresses the need by:
* Hot fix