### PR TITLE
Fix unescape visual mode

### DIFF
--- a/autoload/shuffle.vim
+++ b/autoload/shuffle.vim
@@ -26,7 +26,8 @@ function! shuffle#OrderParams(sort, fold) abort
     let init_line = line( '.' )
     let tmp_string = @@
     execute "normal! " . column . "|"
-    execute "normal! vi)y\<esc>"
+    execute "normal! vi)y"
+    execute "normal! \<esc>"
     let selected_string = @@
     let @@ = tmp_string
     
@@ -47,7 +48,12 @@ function! shuffle#OrderParams(sort, fold) abort
     endif
 
     let joined_string = join( list_items, s:glue )
-    execute 's/'. selected_string . '/'. s:newline . joined_string . s:newline . s:trailing
+    try
+        execute 's/'. selected_string . '/'. s:newline . joined_string . s:newline . s:trailing
+    catch
+        return
+    endtry
+    
     if !a:fold
         execute (init_line + 1) . ',' . (init_line + items_len) . repeat( '>', indent_times )
     endif

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -2,6 +2,12 @@
 
 echo 'Running test cases ...'
 
+LOG_TEST_DIR='./test/logs/'
+if [ ! -d "$LOG_TEST_DIR" ]; then
+    echo "Creating logs folder"
+    mkdir -p $LOG_TEST_DIR
+fi
+
 for f in ./test/tests/*.vim; do
     echo "Test file: $f"
     vim --clean -S ./test/run_test.vim "$f" || exit 1


### PR DESCRIPTION
Why:
* With no params, visual select didn't escape
This change addresses the need by:
* Fix bug